### PR TITLE
check for ready grafana and bump+tag to grafana:4.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM grafana/grafana
+FROM grafana/grafana:4.0.2
 MAINTAINER Lukas Loesche <lloesche@fedoraproject.org>
 
 EXPOSE 3000
 
 RUN apt-get update && \
-    apt-get -y install python3-minimal python3-requests && \
+    apt-get -y install python3-minimal python3-requests curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -16,5 +16,3 @@ RUN chmod +x /bin/promdtsrcadd /bin/startup /bin/dumb-init
 
 ENTRYPOINT [ "/bin/dumb-init", "--" ]
 CMD ["/bin/startup"]
-
-

--- a/startup
+++ b/startup
@@ -11,8 +11,11 @@ echo "Starting Grafana"
 
 trap "kill -TERM $grafana_pid; wait $grafana_pid" EXIT
 
-echo "Waiting 5 seconds before trying to add Prometheus on DC/OS datasource"
-sleep 5
+until $(curl --output /dev/null --silent --head --fail http://localhost:3000); do
+    echo "Grafana not ready. Waiting 5 seconds before trying to add Prometheus on DC/OS datasource"
+    sleep 5
+done
+
 /bin/promdtsrcadd -l "${GF_SECURITY_ADMIN_USER:-admin}" \
                   -p "${GF_SECURITY_ADMIN_PASSWORD:-admin}" \
                   -pu "${PROMETHEUS_URI}" \


### PR DESCRIPTION
when grafana takes more then 5 secs to start (like it did for me) startup fails = container kill